### PR TITLE
Better handling of onData

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,14 +74,14 @@ Each API call is represented as a request object that has the following properti
 ```ts
 {
   // Svelte store that contains a promise for an API call.
-  // If you reload the requets using reload() function, this store will be updated
+  // If you reload the requets using reload() function, this store will be updated.
   ready,
-  // Promise for the initial API call. Will not be updated by `reload()` function.
+  // Promise for the API call.
   // Useful for server code and places where you can't use the `ready` store.
   onData,
   // Svelte store containing the response of the API call.
   resp,
-  // Function that reloads the request with the same parameteres
+  // Function that reloads the request with the same parameteres.
   reload,
 }
 ```

--- a/src/svelte/types.ts
+++ b/src/svelte/types.ts
@@ -16,9 +16,9 @@ export type ApiResponse<R> = SuccessfulResp<R> | FailedResp
 
 export type ApiRequest<R = any> = {
   readonly resp: Writable<ApiResponse<R> | undefined>
-  readonly onData: Promise<ApiResponse<R>>
   readonly ready: Writable<undefined | Promise<ApiResponse<R>>>
-  readonly reload: () => Promise<ApiResponse<R>>
+  reload: () => Promise<ApiResponse<R>>
+  onData: Promise<ApiResponse<R>>
 }
 
 export type SvelteTypedWrappedFetch<OP> = (

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -140,4 +140,19 @@ describe('fetch', () => {
     const { data } = await request.onData
     expect(data.headers).toEqual({ ...expectedHeaders, admin: 'true' })
   })
+
+  it('reloads', async () => {
+    const fun = apity.path('/counter').method('get').create()
+
+    const request = fun({})
+    const { data } = await request.onData
+    expect(data.counter).toEqual(1)
+
+    const secondResp = await request.reload()
+    expect(secondResp.data.counter).toEqual(2)
+
+    request.reload()
+    const thirdResp = await request.onData
+    expect(thirdResp.data.counter).toEqual(3)
+  })
 })

--- a/test/mocks/handlers.ts
+++ b/test/mocks/handlers.ts
@@ -37,6 +37,21 @@ function getResult(
   )
 }
 
+let counter = 0
+
+function getCounterResult(
+  req: RestRequest,
+  res: ResponseComposition,
+  ctx: RestContext,
+) {
+  counter += 1
+  return res(
+    ctx.json({
+      counter,
+    }),
+  )
+}
+
 const HOST = 'https://api.backend.dev'
 
 const methods = {
@@ -50,6 +65,7 @@ const methods = {
   withBodyAndQuery: ['post', 'put', 'patch', 'delete'].map((method) => {
     return (rest as any)[method](`${HOST}/bodyquery/:id`, getResult)
   }),
+  counter: (rest as any)['get'](`${HOST}/counter`, getCounterResult),
   withError: [
     rest.get(`${HOST}/error/:status`, (req, res, ctx) => {
       const status = Number(req.params.status)
@@ -78,6 +94,7 @@ const methods = {
 }
 
 export const handlers = [
+  methods.counter,
   ...methods.withQuery,
   ...methods.withBody,
   ...methods.withBodyArray,

--- a/test/paths.ts
+++ b/test/paths.ts
@@ -69,6 +69,14 @@ export type paths = {
       }
     }
   }
+  '/counter': {
+    get: {
+      parameters: {}
+      responses: {
+        200: { counter: number }
+      }
+    }
+  }
   '/error/{status}': {
     get: {
       parameters: {


### PR DESCRIPTION
Now `onData` should be updated with a new promise once a request is reloaded.