### PR TITLE
Rename onData into result

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ type ApiRequest<R = any> = {
   readonly resp: Writable<ApiResponse<R> | undefined>
 
   // Svelte store that contains a promise for an API call.
-  // If you reload the requets using reload() function, this store will be updated.
+  // If you reload the request using reload() function, this store will be updated.
   readonly ready: Writable<undefined | Promise<ApiResponse<R>>>
 
   // Function that reloads the request with the same parameteres.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ type ApiRequest<R = any> = {
   // If you reload the request using reload() function, this store will be updated.
   readonly ready: Writable<undefined | Promise<ApiResponse<R>>>
 
-  // Function that reloads the request with the same parameteres.
+  // Function that reloads the request with the same parameters.
   reload: () => Promise<ApiResponse<R>>
 
   // Promise for the API call.

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ export async function load({ fetch }) {
   const request = findPetByStatus({ status: 'sold' })
   const resp = await request.result
   if (resp.ok) {
-    return { pets: resp.data, error: '' }
+    return { pets: resp.data, error: undefined }
   } else {
     return { pets: [], error: 'Failed to load pets' }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cocreators-ee/apity",
   "description": "A typed fetch client for openapi-typescript with Svelte support",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "readme": "README.md",
   "engines": {
     "node": ">= 12.0.0",

--- a/src/svelte/fetcher.ts
+++ b/src/svelte/fetcher.ts
@@ -69,6 +69,8 @@ function fetchUrl<R>(request: Request) {
     reload,
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     onData: new Promise(() => {}),
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    result: new Promise(() => {}),
   } as ApiRequest<R>
 
   const apiCall: () => Promise<ApiResponse<R>> = () => {
@@ -77,7 +79,8 @@ function fetchUrl<R>(request: Request) {
       unsubscribe = resp.subscribe((r) => {
         if (typeof r !== 'undefined' && r.data === result.data) {
           resolve(r)
-          retVal.onData = Promise.resolve(r)
+          retVal.result = Promise.resolve(r)
+          retVal.onData = retVal.result
           if (unsubscribe) {
             unsubscribe()
             unsubscribe = undefined
@@ -96,11 +99,13 @@ function fetchUrl<R>(request: Request) {
       unsubscribe = undefined
     }
     const apiCallPromise = apiCall()
+    retVal.result = apiCallPromise
     retVal.onData = apiCallPromise
     return apiCallPromise
   }
 
-  retVal.onData = apiCall()
+  retVal.result = apiCall()
+  retVal.onData = retVal.result
   retVal.reload = reload
   return retVal
 }

--- a/src/svelte/fetcher.ts
+++ b/src/svelte/fetcher.ts
@@ -68,6 +68,7 @@ function fetchUrl<R>(request: Request) {
     ready,
     reload,
     // eslint-disable-next-line @typescript-eslint/no-empty-function
+    // Deprecated field. Will be removed in one of the major updates
     onData: new Promise(() => {}),
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     result: new Promise(() => {}),

--- a/src/svelte/types.ts
+++ b/src/svelte/types.ts
@@ -18,6 +18,8 @@ export type ApiRequest<R = any> = {
   readonly resp: Writable<ApiResponse<R> | undefined>
   readonly ready: Writable<undefined | Promise<ApiResponse<R>>>
   reload: () => Promise<ApiResponse<R>>
+  result: Promise<ApiResponse<R>>
+  // legacy field. will be removed in one of the major updates
   onData: Promise<ApiResponse<R>>
 }
 

--- a/src/svelte/types.ts
+++ b/src/svelte/types.ts
@@ -19,7 +19,7 @@ export type ApiRequest<R = any> = {
   readonly ready: Writable<undefined | Promise<ApiResponse<R>>>
   reload: () => Promise<ApiResponse<R>>
   result: Promise<ApiResponse<R>>
-  // legacy field. will be removed in one of the major updates
+  // deprecated field. will be removed in one of the major updates
   onData: Promise<ApiResponse<R>>
 }
 

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -40,7 +40,7 @@ describe('fetch', () => {
       scalar: 'a',
       list: ['b', 'c'],
     })
-    const { ok, status, data } = await request.onData
+    const { ok, status, data } = await request.result
 
     expect(data.params).toEqual({ a: '1', b: '%2F' })
     expect(data.query).toEqual({ scalar: 'a', list: ['b', 'c'] })
@@ -58,7 +58,7 @@ describe('fetch', () => {
         id: 1,
         list: ['b', 'c'],
       })
-      const { data } = await request.onData
+      const { data } = await request.result
       expect(data.params).toEqual({ id: '1' })
       expect(data.body).toEqual({ list: ['b', 'c'] })
       expect(data.query).toEqual({})
@@ -70,7 +70,7 @@ describe('fetch', () => {
       const fun = apity.path('/bodyarray/{id}').method(method).create()
 
       const request = fun(arrayRequestBody(['b', 'c'], { id: 1 }))
-      const { data } = await request.onData
+      const { data } = await request.result
 
       expect(data.params).toEqual({ id: '1' })
       expect(data.body).toEqual(['b', 'c'])
@@ -90,7 +90,7 @@ describe('fetch', () => {
         scalar: 'a',
         list: ['b', 'c'],
       })
-      const { data } = await request.onData
+      const { data } = await request.result
       expect(data.params).toEqual({ id: '1' })
       expect(data.body).toEqual({ list: ['b', 'c'] })
       expect(data.query).toEqual({ scalar: 'a' })
@@ -101,7 +101,7 @@ describe('fetch', () => {
     const fun = apity.path('/body/{id}').method('delete').create()
 
     const request = fun({ id: 1 } as any)
-    const { data } = await request.onData
+    const { data } = await request.result
 
     expect(data.params).toEqual({ id: '1' })
     expect(data.headers).toHaveProperty('accept')
@@ -111,7 +111,7 @@ describe('fetch', () => {
   it(`POST /nocontent`, async () => {
     const fun = apity.path('/nocontent').method('post').create()
     const request = fun(undefined)
-    const { data, status } = await request.onData
+    const { data, status } = await request.result
     expect(status).toBe(204)
     expect(data).toBeUndefined()
   })
@@ -120,14 +120,14 @@ describe('fetch', () => {
     const fun = apity.path('/counter').method('get').create()
 
     const request = fun({})
-    const { data } = await request.onData
+    const { data } = await request.result
     expect(data.counter).toEqual(1)
 
     const secondResp = await request.reload()
     expect(secondResp.data.counter).toEqual(2)
 
     request.reload()
-    const thirdResp = await request.onData
+    const thirdResp = await request.result
     expect(thirdResp.data.counter).toEqual(3)
   })
 })


### PR DESCRIPTION
Replace `onData` with `result`. Didn't remove `onData` completely for backward compatibility.