### PR TITLE
Support text and binary responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cocreators-ee/apity",
   "description": "A typed fetch client for openapi-typescript with Svelte support",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "readme": "README.md",
   "engines": {
     "node": ">= 12.0.0",

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,9 +39,11 @@ type OpResponseTypes<OP> = OP extends {
         ? S
         : R[S] extends { content: { 'application/json': infer C } } // openapi 3
         ? C
+        : R[S] extends TextContentType
+        ? string
         : S extends 'default'
         ? R[S]
-        : unknown
+        : Blob
     }
   : never
 
@@ -197,4 +199,13 @@ export class ApiError extends Error {
     this.statusText = response.statusText
     this.data = response.data
   }
+}
+
+type TextContentType = {
+  content:
+    | { 'text/plain': any }
+    | { 'text/css': any }
+    | { 'text/csv': any }
+    | { 'text/html': any }
+    | { 'text/javascript': any }
 }


### PR DESCRIPTION
Now the library will check the `content-type` header in a response and return a `.json()`, `.blob()` or `.text()` based on the value.