### PR TITLE
feat: support array in search params query string

### DIFF
--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -25,12 +25,14 @@ function queryString(params: Record<string, unknown>): string {
 
   const encode = (key: string, value: unknown) =>
     `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`
-
+  const encodeArray = (key, value) => 
+    `${encodeURIComponent(key)}[]=${encodeURIComponent(String(value))}`;
+  
   Object.keys(params).forEach((key) => {
     const value = params[key]
     if (value != null) {
       if (Array.isArray(value)) {
-        value.forEach((value) => qs.push(encode(key, value)))
+        value.forEach((value) => qs.push(encodeArray(key, value)))
       } else {
         qs.push(encode(key, value))
       }


### PR DESCRIPTION
support [array](https://github.com/sindresorhus/query-string?tab=readme-ov-file#arrayformat) format in url search params.

A future direction may be to support more array format.

```typescript
{foo: ['1', '2', '3']}
//=> 'foo[]=1&foo[]=2&foo[]=3'
```