### PR TITLE
feat: allow reconfiguring Apity after fetch operations creation

### DIFF
--- a/src/svelte/fetcher.ts
+++ b/src/svelte/fetcher.ts
@@ -82,7 +82,7 @@ async function fetchAndParse<R>(request: Request): Promise<ApiResponse<R>> {
 
 function fetchUrl<R>(request: Request) {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  const ready = writable<Promise<ApiResponse<R>>>(new Promise(() => {}))
+  const ready = writable<Promise<ApiResponse<R>>>(new Promise(() => { }))
   const resp = writable<ApiResponse<R> | undefined>()
   let unsubscribe: Unsubscriber | undefined = undefined
 
@@ -92,9 +92,9 @@ function fetchUrl<R>(request: Request) {
     reload,
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     // Deprecated field. Will be removed in one of the major updates
-    onData: new Promise(() => {}),
+    onData: new Promise(() => { }),
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    result: new Promise(() => {}),
+    result: new Promise(() => { }),
   } as ApiRequest<R>
 
   const apiCall: () => Promise<ApiResponse<R>> = () => {
@@ -170,13 +170,17 @@ function createFetch<OP>(fetch: _TypedWrappedFetch<OP>): TypedWrappedFetch<OP> {
 }
 
 function fetcher<Paths>() {
-  let baseUrl = ''
-  let defaultInit: RequestInit = {}
+  let defaultConfig: FetchConfig = {
+    baseUrl: '',
+    init: {},
+    use: []
+  }
 
   return {
     configure: (config: FetchConfig) => {
-      baseUrl = config.baseUrl || ''
-      defaultInit = config.init || {}
+      defaultConfig.baseUrl = config.baseUrl || '';
+      defaultConfig.init = config.init || {};
+      defaultConfig.use = config.use || []
     },
     path: <P extends keyof Paths>(path: P) => ({
       method: <M extends keyof Paths[P]>(method: M) => ({
@@ -184,13 +188,13 @@ function fetcher<Paths>() {
           const fn = createFetch((payload, realFetch, init) =>
             // @ts-ignore
             fetchUrl({
-              baseUrl: baseUrl || '',
               path: path as string,
               method: method as Method,
               queryParams: Object.keys(queryParams || {}),
               payload,
-              init: mergeRequestInit(defaultInit, init),
+              init: init,
               realFetch: realFetch || fetch,
+              config: defaultConfig
             }),
           )
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,16 +35,16 @@ type OpResponseTypes<OP> = OP extends {
   responses: infer R
 }
   ? {
-      [S in keyof R]: R[S] extends { schema?: infer S } // openapi 2
-        ? S
-        : R[S] extends { content: { 'application/json': infer C } } // openapi 3
-        ? C
-        : R[S] extends TextContentType
-        ? string
-        : S extends 'default'
-        ? R[S]
-        : Blob
-    }
+    [S in keyof R]: R[S] extends { schema?: infer S } // openapi 2
+    ? S
+    : R[S] extends { content: { 'application/json': infer C } } // openapi 3
+    ? C
+    : R[S] extends TextContentType
+    ? string
+    : S extends 'default'
+    ? R[S]
+    : Blob
+  }
   : never
 
 type _OpReturnType<T> = 200 extends keyof T
@@ -137,8 +137,8 @@ type _CreateFetch<OP, Q = never> = [Q] extends [never]
 
 export type CreateFetch<M, OP> = M extends 'post' | 'put' | 'patch' | 'delete'
   ? OP extends { parameters: { query: infer Q } }
-    ? _CreateFetch<OP, { [K in keyof Q]: true | 1 }>
-    : _CreateFetch<OP>
+  ? _CreateFetch<OP, { [K in keyof Q]: true | 1 }>
+  : _CreateFetch<OP>
   : _CreateFetch<OP>
 
 export type Middleware = (
@@ -154,12 +154,12 @@ export type FetchConfig = {
 }
 
 export type Request = {
-  baseUrl: string
   method: Method
   path: string
   queryParams: string[] // even if a post these will be sent in query
   payload: any
   init?: RequestInit
+  config: FetchConfig
   realFetch: RealFetch
 }
 
@@ -203,10 +203,10 @@ export class ApiError extends Error {
 
 type TextContentType = {
   content:
-    | { 'text/css': any }
-    | { 'text/csv': any }
-    | { 'text/html': any }
-    | { 'text/javascript': any }
-    | { 'text/plain': any }
-    | { 'text/xml': any }
+  | { 'text/css': any }
+  | { 'text/csv': any }
+  | { 'text/html': any }
+  | { 'text/javascript': any }
+  | { 'text/plain': any }
+  | { 'text/xml': any }
 }


### PR DESCRIPTION
The Apity global singleton cannot be reconfigured after the first config along with defined operations. The reconfiguration does not take any effect.

Say we have configure apity and defined some fetch operations. And we set a `Authorization` field in headers which should be passed to backend server. 
```typescript
export const apity = Apity.for<paths>();
apity.configure({
	// Base URL to your API
	baseUrl: '',
	// RequestInit options, e.g. default headers
	init: {
		headers: { Authorization: `Bearer ${keycloak.token}` }
	},
});

export const fetchTasks = apity.path('/tasks').method('get').create();
```

However, the token is short lived (typically 5 minutes) and routinely reacquired with a refresh token. Then we need to update the `defaultInit`'s headers. But calling `apity.configure()` when acquires a new token does not take any effect. This is because in the following codes, `init` is finalized when calling `create()` in operation definition and any changes to `defaultInit` afterward do not affect the finalized `init`. 
```typescript
        create: function (queryParams?: Record<string, true | 1>) {
          const fn = createFetch((payload, realFetch, init) =>
            fetchUrl({
              baseUrl: baseUrl || '', // baseUrl is fixed here, should be composed lazily
              path: path as string,
              method: method as Method,
              queryParams: Object.keys(queryParams || {}),
              payload,
              init: mergeRequestInit(defaultInit, init), // init is fixed here, should be composed lazily
              realFetch: realFetch || fetch,
// ...
```
# How to fix
This PR use an Object to store `baseUrl` and `init`, and Objects in JavaScript are passed by reference. Ane we lazily compose `init` when inside `fetchUrl` function instead of function declaration.