### PR TITLE
fix(svelte): parse Content-Type properly when directives are also specified in getResponseBody

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cocreators-ee/apity",
   "description": "A typed fetch client for openapi-typescript with Svelte support",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "readme": "README.md",
   "engines": {
     "node": ">= 12.0.0",

--- a/src/svelte/fetcher.ts
+++ b/src/svelte/fetcher.ts
@@ -23,8 +23,16 @@ async function getResponseBody(response: LimitedResponse) {
   if (response.status === 204) {
     return undefined
   }
+
   const contentType = response.headers.get('content-type')
-  if (contentType && JSON_CONTENT_TYPES.includes(contentType)) {
+  let isJsonResp = false
+  if (contentType) {
+    isJsonResp = JSON_CONTENT_TYPES.some((jsonContentType) =>
+      contentType?.includes(jsonContentType),
+    )
+  }
+
+  if (contentType && isJsonResp) {
     return await response.json()
   } else if (contentType && contentType.indexOf('text') === -1) {
     // if the response is neither JSON nor text, return binary data as is


### PR DESCRIPTION
Fixes #20 
